### PR TITLE
Adding 'main' object to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,8 @@
     "type": "git",
     "url": "git@github.com:salesforce-ux/design-system.git"
   },
-  "author": "Salesforce"  
+  "author": "Salesforce",
+  "main": [
+  	"assets/styles/salesforce-lightning-design-system.css"
+  ]
 }


### PR DESCRIPTION
Hi - Thanks for putting up a bower package for us to use! I was hoping you could provide a 'main' configuration in the bower.json file so that people using things like wiredep would get resource entry-points auto-included in their project.

See the bower spec here for more information:
https://github.com/bower/spec/blob/master/json.md#main

It is an optional, but recommended config section in the spec.

I forked and tested the change in my local app and everything worked well. If you care to - I've attached a pull request w/ the change.

Thanks!
